### PR TITLE
Change how we're hiding modules from the webpack output

### DIFF
--- a/base.webpack.config.js
+++ b/base.webpack.config.js
@@ -123,7 +123,8 @@ exports.merge = function merge(additionConfig) {
       ],
       stats: {
         maxModules: Infinity,
-        optimizationBailout: true
+        optimizationBailout: true,
+        modules: false
       }
     }].concat(typeof additionConfig === 'function' ? additionConfig(env, argv) : additionConfig));
   }

--- a/build.xml
+++ b/build.xml
@@ -671,7 +671,6 @@
       <env key="BROWSERSLIST_ENV" value="${browserslistEnv}"/>
       <env key="BROWSERSLIST_CONFIG" value="${projectsDir}/install/.browserslistrc"/>
       <arg line="${webpack.env}"/>
-      <arg line="--hide-modules"/>
     </exec>
   </target>
 


### PR DESCRIPTION
Context: the upcoming Webpack Dev Server depends on a version of `webpack-cli` in which the `--hide-modules` CLI option has been discontinued.