### PR TITLE
Update browserslist to include wider support

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -6,7 +6,7 @@ last 2 edge versions
 last 2 ios versions
 
 [legacy]
-> 0%, not dead
+> 0%
 
 [test]
 current node

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -6,7 +6,7 @@ last 2 edge versions
 last 2 ios versions
 
 [legacy]
-> 1%
+> 0%, not dead
 
 [test]
 current node

--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.1",
     "webpack-merge": "^4.2.1"
-  }
+  },
+  "version": "0.0.1"
 }


### PR DESCRIPTION
Addresses issue #20.

In comparing `'> 0%, not dead'` to our users' browsers on AWS, the IE users stood out. Doing `'> 0%, not dead'` covers only IE11 and essentially every version of every other major browser.

But we have some regular users that use IE11 and below. By doing simply `'> 0%'`, all users' IE versions get polyfilled.

The real question is whether we need/want to increase the bundle size with so much antiquated browser support. Based on the usage statistics, the IE users may not be experiencing unworkable errors.