### PR TITLE
Add --frozen-lockfile option to all yarn installs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -511,6 +511,7 @@
           failonerror="true"
           failifexecutionfails="true">
       <arg line="--ignore-engines"/>
+      <arg line="--frozen-lockfile"/>
     </exec>
   </target>
 
@@ -528,6 +529,7 @@
       failonerror="true"
       failifexecutionfails="true">
       <arg line="--ignore-engines"/>
+      <arg line="--frozen-lockfile"/>
     </exec>
   </target>
 


### PR DESCRIPTION
This is a safety rail to help prevent npm-based attacks.

With this change, builds will intentionally fail if the `yarn.lock` file is missing.

We should make sure all relevant repos have a `yarn.lock` (and don't include any infected packages).

I did rebuilder on `bmaccallum.vectorbase.org` with this change and it worked.

We'd need to check that it doesn't break Jenkins site builds, I guess?